### PR TITLE
新機能: APIを叩く場合のエラーハンドリング

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		D487C49929AA7B0200022E3C /* WebUIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D487C49829AA7B0200022E3C /* WebUIViewController.swift */; };
 		D487C49B29AAE9D900022E3C /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D487C49A29AAE9D900022E3C /* APIError.swift */; };
 		D487C49D29AAF32C00022E3C /* APIErrorAlart.swift in Sources */ = {isa = PBXBuildFile; fileRef = D487C49C29AAF32C00022E3C /* APIErrorAlart.swift */; };
+		D487C4A529AB179D00022E3C /* Loaf in Frameworks */ = {isa = PBXBuildFile; productRef = D487C4A429AB179D00022E3C /* Loaf */; };
 		D4A1C06B29A4B5BB00673AA7 /* Repositories.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A1C06A29A4B5BB00673AA7 /* Repositories.swift */; };
 /* End PBXBuildFile section */
 
@@ -77,6 +78,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D487C4A529AB179D00022E3C /* Loaf in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -209,6 +211,9 @@
 			dependencies = (
 			);
 			name = iOSEngineerCodeCheck;
+			packageProductDependencies = (
+				D487C4A429AB179D00022E3C /* Loaf */,
+			);
 			productName = iOSEngineerCodeCheck;
 			productReference = BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */;
 			productType = "com.apple.product-type.application";
@@ -281,6 +286,9 @@
 				Base,
 			);
 			mainGroup = BFD945D2244DC5E80012785A;
+			packageReferences = (
+				D487C4A329AB179D00022E3C /* XCRemoteSwiftPackageReference "Loaf" */,
+			);
 			productRefGroup = BFD945DC244DC5E80012785A /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -693,6 +701,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		D487C4A329AB179D00022E3C /* XCRemoteSwiftPackageReference "Loaf" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/schmidyy/Loaf";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.7.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		D487C4A429AB179D00022E3C /* Loaf */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D487C4A329AB179D00022E3C /* XCRemoteSwiftPackageReference "Loaf" */;
+			productName = Loaf;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = BFD945D3244DC5E80012785A /* Project object */;
 }

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		D487C48229A8474400022E3C /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D487C48129A8474400022E3C /* RequestTests.swift */; };
 		D487C48A29A85D6200022E3C /* RepositoriesTableUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D487C48529A8596A00022E3C /* RepositoriesTableUITest.swift */; };
 		D487C49929AA7B0200022E3C /* WebUIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D487C49829AA7B0200022E3C /* WebUIViewController.swift */; };
+		D487C49B29AAE9D900022E3C /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D487C49A29AAE9D900022E3C /* APIError.swift */; };
+		D487C49D29AAF32C00022E3C /* APIErrorAlart.swift in Sources */ = {isa = PBXBuildFile; fileRef = D487C49C29AAF32C00022E3C /* APIErrorAlart.swift */; };
 		D4A1C06B29A4B5BB00673AA7 /* Repositories.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A1C06A29A4B5BB00673AA7 /* Repositories.swift */; };
 /* End PBXBuildFile section */
 
@@ -65,6 +67,8 @@
 		D487C48329A8490A00022E3C /* iOSEngineerCodeCheck.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = iOSEngineerCodeCheck.xctestplan; sourceTree = "<group>"; };
 		D487C48529A8596A00022E3C /* RepositoriesTableUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoriesTableUITest.swift; sourceTree = "<group>"; };
 		D487C49829AA7B0200022E3C /* WebUIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebUIViewController.swift; sourceTree = "<group>"; };
+		D487C49A29AAE9D900022E3C /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
+		D487C49C29AAF32C00022E3C /* APIErrorAlart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIErrorAlart.swift; sourceTree = "<group>"; };
 		D4A1C06A29A4B5BB00673AA7 /* Repositories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repositories.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -182,6 +186,8 @@
 			isa = PBXGroup;
 			children = (
 				D4A1C06A29A4B5BB00673AA7 /* Repositories.swift */,
+				D487C49A29AAE9D900022E3C /* APIError.swift */,
+				D487C49C29AAF32C00022E3C /* APIErrorAlart.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -344,8 +350,10 @@
 				BFD945E3244DC5E80012785A /* RepositoriesTableViewController.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */,
 				D4A1C06B29A4B5BB00673AA7 /* Repositories.swift in Sources */,
+				D487C49B29AAE9D900022E3C /* APIError.swift in Sources */,
 				D487C47929A7B29400022E3C /* Request.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
+				D487C49D29AAF32C00022E3C /* APIErrorAlart.swift in Sources */,
 				D487C49929AA7B0200022E3C /* WebUIViewController.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 				D487C47B29A7B39600022E3C /* RepositoryDetailViewModel.swift in Sources */,

--- a/iOSEngineerCodeCheck/Model/Entity/APIError.swift
+++ b/iOSEngineerCodeCheck/Model/Entity/APIError.swift
@@ -9,6 +9,8 @@
 import Foundation
 
 enum APIError: Error {
+    case searchWordEmpty
+    case containsSpacialWord
     // クライアントエラー
     case badrequest  // 400
     case unauthorized  // 401
@@ -21,6 +23,10 @@ enum APIError: Error {
 
     var _code: Int {
         switch self {
+        case .searchWordEmpty:
+            return 0
+        case .containsSpacialWord:
+            return 1
         case .badrequest:
             return 400
         case .unauthorized:
@@ -40,6 +46,8 @@ enum APIError: Error {
 
     var title: String {
         switch self {
+        case .searchWordEmpty, .containsSpacialWord:
+            return "Error Search Word"
         case .badrequest:
             return "400 Bad Request"
         case .unauthorized:
@@ -57,6 +65,10 @@ enum APIError: Error {
 
     var description: String {
         switch self {
+        case .searchWordEmpty:
+            return "検索文字が空です"
+        case .containsSpacialWord:
+            return "特殊文字が検索文字に含まれています"
         case .badrequest:
             return "クライントエラー"
         case .unauthorized:
@@ -74,6 +86,10 @@ enum APIError: Error {
 
     init(statusCode: Int) {
         switch statusCode {
+        case 0:
+            self = .searchWordEmpty
+        case 1:
+            self = .containsSpacialWord
         case 400:
             self = .badrequest
         case 401:

--- a/iOSEngineerCodeCheck/Model/Entity/APIError.swift
+++ b/iOSEngineerCodeCheck/Model/Entity/APIError.swift
@@ -1,0 +1,93 @@
+//
+//  APIError.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 濵田　悠樹 on 2023/02/26.
+//  Copyright © 2023 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+enum APIError: Error {
+    // クライアントエラー
+    case badrequest         // 400
+    case unauthorized       // 401
+    case forbidden          // 403
+    case notfound           // 404
+    case validationFailed   // 422
+    // サーバーエラー
+    case server(Int)        // 500台
+    case unknown(Int)       // 200台+上記 以外
+
+    var _code: Int {
+        switch self {
+        case .badrequest:
+            return 400
+        case .unauthorized:
+            return 401
+        case .forbidden:
+            return 403
+        case .notfound:
+            return 404
+        case .validationFailed:
+            return 422
+        case .server(let statusCode):
+            return statusCode
+        case .unknown(let statusCode):
+            return statusCode
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .badrequest:
+            return "400 Bad Request"
+        case .unauthorized:
+            return "401 Unauthorized"
+        case .forbidden:
+            return "403 Forbidden"
+        case .notfound:
+            return "404 Not Found"
+        case .validationFailed:
+            return "422 Unprocessable Entity"
+        default:
+            return "サーバーエラー"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .badrequest:
+            return "クライントエラー"
+        case .unauthorized:
+            return "認証に関するエラー"
+        case .forbidden:
+            return "閲覧権限に関するエラー"
+        case .notfound:
+            return "ページが存在しないエラー"
+        case .validationFailed:
+            return "処理が行われないエラー"
+        default:
+            return "サーバーに関するエラー"
+        }
+    }
+
+    init(statusCode: Int) {
+        switch statusCode {
+        case 400:
+            self = .badrequest
+        case 401:
+            self = .unauthorized
+        case 403:
+            self = .forbidden
+        case 404:
+            self = .notfound
+        case 422:
+            self = .validationFailed
+        case 500..<600:
+            self = .server(statusCode)
+        default:
+            self = .unknown(statusCode)
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/Model/Entity/APIError.swift
+++ b/iOSEngineerCodeCheck/Model/Entity/APIError.swift
@@ -10,14 +10,14 @@ import Foundation
 
 enum APIError: Error {
     // クライアントエラー
-    case badrequest         // 400
-    case unauthorized       // 401
-    case forbidden          // 403
-    case notfound           // 404
-    case validationFailed   // 422
+    case badrequest  // 400
+    case unauthorized  // 401
+    case forbidden  // 403
+    case notfound  // 404
+    case validationFailed  // 422
     // サーバーエラー
-    case server(Int)        // 500台
-    case unknown(Int)       // 200台+上記 以外
+    case server(Int)  // 500台
+    case unknown(Int)  // 200台+上記 以外
 
     var _code: Int {
         switch self {

--- a/iOSEngineerCodeCheck/Model/Entity/APIErrorAlart.swift
+++ b/iOSEngineerCodeCheck/Model/Entity/APIErrorAlart.swift
@@ -1,0 +1,19 @@
+//
+//  APIErrorAlart.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 濵田　悠樹 on 2023/02/26.
+//  Copyright © 2023 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+struct APIErrorAlart {
+    var title: String
+    var description: String
+
+    init(title: String, description: String) {
+        self.title = title
+        self.description = description
+    }
+}

--- a/iOSEngineerCodeCheck/Model/Request.swift
+++ b/iOSEngineerCodeCheck/Model/Request.swift
@@ -10,8 +10,10 @@ import Foundation
 
 class Request {
     func fetchData(url: String) async throws -> Result<Data, APIError> {
-        var request = URLRequest(url: URL(string: url)!)
+        guard let url = URL(string: url) else { return .failure(.containsSpacialWord) }
+        var request = URLRequest(url: url)
         request.httpMethod = "GET"
+
         let (data, response) = try await URLSession.shared.data(for: request)
         // エラーハンドリング
         if let response = response as? HTTPURLResponse {

--- a/iOSEngineerCodeCheck/Model/Request.swift
+++ b/iOSEngineerCodeCheck/Model/Request.swift
@@ -9,10 +9,29 @@
 import Foundation
 
 class Request {
-    func fetchData(url: String) async throws -> Data {
+    func fetchData(url: String) async throws -> Result<Data, APIError> {
         var request = URLRequest(url: URL(string: url)!)
         request.httpMethod = "GET"
-        let (data, _) = try await URLSession.shared.data(for: request)
-        return data
+        let (data, response) = try await URLSession.shared.data(for: request)
+        // エラーハンドリング
+        if let response = response as? HTTPURLResponse {
+            switch response.statusCode {
+            case 400:
+                return .failure(.badrequest)
+            case 401:
+                return .failure(.unauthorized)
+            case 403:
+                return .failure(.forbidden)
+            case 404:
+                return .failure(.notfound)
+            case 422:
+                return .failure(.validationFailed)
+            case 500..<600:
+                return .failure(.server(response.statusCode))
+            default:
+                break
+            }
+        }
+        return .success(data)
     }
 }

--- a/iOSEngineerCodeCheck/View/RepositoriesTableViewController.swift
+++ b/iOSEngineerCodeCheck/View/RepositoriesTableViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import Combine
+import Loaf
 import UIKit
 
 class RepositoriesTableViewController: UITableViewController {
@@ -42,8 +43,17 @@ class RepositoriesTableViewController: UITableViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] apiErrorAlart in
                 guard let self = self else { return }
-                print(apiErrorAlart.title)
-                print(apiErrorAlart.description)
+                if !apiErrorAlart.title.isEmpty && !apiErrorAlart.description.isEmpty {
+                    // エラー表示
+                    Loaf(apiErrorAlart.description, state: .custom(.init(backgroundColor: .systemPink, width: .screenPercentage(0.8))), location: .top, sender: self).show(.short) { dismissalType in
+                        switch dismissalType {
+                        case .tapped:
+                            print("Tapped!")
+                        case .timedOut:
+                            print("Timmed out!")
+                        }
+                    }
+                }
             }
             .store(in: &cancellable)
     }

--- a/iOSEngineerCodeCheck/View/RepositoriesTableViewController.swift
+++ b/iOSEngineerCodeCheck/View/RepositoriesTableViewController.swift
@@ -33,8 +33,17 @@ class RepositoriesTableViewController: UITableViewController {
             .receive(on: DispatchQueue.main)  // .sink{ }内で DispatchQueue.main.async を実行するようなもの
             .sink { [weak self] repositories in
                 guard let self = self else { return }
-                self.repositories = repositories
+                self.repositories = repositories  // TODO: レスポンスを正常に受け取ったが、中身が空の時アラート表示
                 self.tableView.reloadData()
+            }
+            .store(in: &cancellable)
+
+        repositoriesTableViewModel.$apiErrorAlart
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] apiErrorAlart in
+                guard let self = self else { return }
+                print(apiErrorAlart.title)
+                print(apiErrorAlart.description)
             }
             .store(in: &cancellable)
     }
@@ -51,7 +60,7 @@ extension RepositoriesTableViewController: UISearchBarDelegate {
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let searchBarText = searchBar.text else { return }
 
-        if !searchBarText.isEmpty {
+        if !searchBarText.trimmingCharacters(in: .whitespaces).isEmpty {
             Task {
                 do {
                     try await repositoriesTableViewModel.setRepositories(searchText: searchBarText)

--- a/iOSEngineerCodeCheck/ViewModel/RepositoriesTableViewModel.swift
+++ b/iOSEngineerCodeCheck/ViewModel/RepositoriesTableViewModel.swift
@@ -13,11 +13,18 @@ class RepositoriesTableViewModel: ObservableObject {
     private let request = Request()
 
     @Published var repositories: [Repository] = []
+    @Published var apiErrorAlart: APIErrorAlart = APIErrorAlart(title: "", description: "")
 
     public func setRepositories(searchText: String) async throws {
         let githubAPISearchUrl = "https://api.github.com/search/repositories?q=\(searchText)"
-        let data = try await request.fetchData(url: githubAPISearchUrl)
-        let repos: Repositories = try! JSONDecoder().decode(Repositories.self, from: data)  // TODO: 変数名変更, Repositoriesの命名から変更
-        repositories = repos.items
+        let result = try await request.fetchData(url: githubAPISearchUrl)
+        switch result {
+        case let .success(data):
+            let repos: Repositories = try! JSONDecoder().decode(Repositories.self, from: data)  // TODO: 変数名変更, Repositoriesの命名から変更
+            repositories = repos.items
+        case let .failure(apiError):
+            apiErrorAlart.title = apiError.title
+            apiErrorAlart.description = apiError.description
+        }
     }
 }

--- a/iOSEngineerCodeCheck/ViewModel/RepositoryDetailViewModel.swift
+++ b/iOSEngineerCodeCheck/ViewModel/RepositoryDetailViewModel.swift
@@ -13,9 +13,16 @@ class RepositoryDetailViewModel: ObservableObject {
     private let request = Request()
 
     @Published public var avatarUIImage = UIImage()
+    @Published var apiErrorAlart: APIErrorAlart = APIErrorAlart(title: "", description: "")
 
     public func setAvatarUIImage(url: String) async throws {
-        let data = try await request.fetchData(url: url)
-        avatarUIImage = UIImage(data: data) ?? UIImage()
+        let result = try await request.fetchData(url: url)
+        switch result {
+        case let .success(data):
+            avatarUIImage = UIImage(data: data) ?? UIImage()
+        case let .failure(apiError):
+            apiErrorAlart.title = apiError.title
+            apiErrorAlart.description = apiError.description
+        }
     }
 }

--- a/iOSEngineerCodeCheckTests/RequestTests.swift
+++ b/iOSEngineerCodeCheckTests/RequestTests.swift
@@ -12,40 +12,40 @@ import XCTest
 
 @MainActor
 class RequestTests: XCTestCase {
-    func test_GithubAPIからリポジトリを取得_成功() {
-        let expectation = expectation(description: "_GithubAPIからリポジトリを取得_成功")
+    func test_GithubAPIからリポジトリを取得_検索結果が複数返ってくる() {
+        let expectation = expectation(description: "_GithubAPIからリポジトリを取得_検索結果が複数返ってくる")
 
         Task {
-            do {
-                let searchText = "swift"
-                let githubAPISearchUrl = "https://api.github.com/search/repositories?q=\(searchText)"
-                let data = try await Request().fetchData(url: githubAPISearchUrl)
+            let searchText = "swift"
+            let githubAPISearchUrl = "https://api.github.com/search/repositories?q=\(searchText)"
+            let result = try await Request().fetchData(url: githubAPISearchUrl)
+            switch result {
+            case let .success(data):
                 let repos: Repositories = try! JSONDecoder().decode(Repositories.self, from: data)
-
                 XCTAssertFalse(repos.items.isEmpty)
                 expectation.fulfill()
-            } catch {
-                XCTFail(error.localizedDescription)
+            case let .failure(apiError):
+                XCTFail("APIError: \(apiError.title)")
             }
         }
 
         wait(for: [expectation], timeout: 10.0)
     }
 
-    func test_GithubAPIからリポジトリを取得_失敗() {
-        let expectation = expectation(description: "_GithubAPIからリポジトリを取得_失敗")
+    func test_GithubAPIからリポジトリを取得_検索結果が空で返ってくる() {
+        let expectation = expectation(description: "_GithubAPIからリポジトリを取得_検索結果が空で返ってくる")
 
         Task {
-            do {
-                let searchText = "hamadahamadahamada"
-                let githubAPISearchUrl = "https://api.github.com/search/repositories?q=\(searchText)"
-                let data = try await Request().fetchData(url: githubAPISearchUrl)
+            let searchText = "hamadahamadahamada"
+            let githubAPISearchUrl = "https://api.github.com/search/repositories?q=\(searchText)"
+            let result = try await Request().fetchData(url: githubAPISearchUrl)
+            switch result {
+            case let .success(data):
                 let repos: Repositories = try! JSONDecoder().decode(Repositories.self, from: data)
-
                 XCTAssertTrue(repos.items.isEmpty)
                 expectation.fulfill()
-            } catch {
-                XCTFail(error.localizedDescription)
+            case let .failure(apiError):
+                XCTFail("APIError: \(apiError.title)")
             }
         }
 


### PR DESCRIPTION
close #23 

- [Loaf](https://github.com/schmidyy/Loaf)を使用してエラーの内容を表示

### 例
```検索文字列の中に特殊文字が含まれている場合```

<img width = 30% src = "https://user-images.githubusercontent.com/55442055/221393808-17feed23-e72e-43b1-b9fd-27ece231df6d.gif">

